### PR TITLE
[update] 設定ファイルにtemplates/synqapp, static, mediaのアクセス設定を追加

### DIFF
--- a/Synq/settings.py
+++ b/Synq/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -120,3 +121,7 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# media files
+MEDIA_URL = "media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")


### PR DESCRIPTION
[参考サイト](https://qiita.com/Saku731/items/ed64190a12a4498b9446#htmlcss-%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E3%83%95%E3%82%A9%E3%83%AB%E3%83%80%E3%82%92%E6%BA%96%E5%82%99)

- HTML/CSS に関するフォルダを準備
- 静的ファイルのアクセス設定
- メディアファイルのアクセス設定

実行したコマンド

```
cd Synq   # manage.pyと同じ階層に移動

mkdir templates
cd templates
mkdir synqapp
touch base.html
cd ..    # manage.pyの階層に移動

mkdir static
cd static
mkdir images css js
cd ..    # manage.pyの階層に移動

mkdir media
```