### PR TITLE
[update] ページ遷移なしでグルーピング画像を表示

### DIFF
--- a/templates/synqapp/image_list.html
+++ b/templates/synqapp/image_list.html
@@ -7,10 +7,42 @@
 {% block contents %}
     <div class="album py-5 bg-body-tertiary">
         <div class="container">
-            <div class="row row-cols-3 row-cols-sm-2 row-cols-md-3 g-3">
+            <div class="row row-cols-5 row-cols-sm-5 row-cols-md-5 g-3">
                 {% for img in image_context_list %}
                     <div class="col">
-                        <div class="card-group">
+{#                        h-100でカードの高さを揃える#}
+                        <div class="card-group h-100">
+                            <div class="card shadow-sm">
+                                {% if img.image %}
+                                    <img src="{{ img.image.url }}" alt="{{ img.name }}の写真">
+{#                                    <img class="img-thumbnail" src="{{ img.image.url }}" alt="{{ img.name }}の写真">#}
+                                {% else %}
+                                    <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
+                                         xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice"
+                                         focusable="false" role="img" aria-label="Placeholder: Image cap">
+                                        <title>Placeholder</title>
+                                        <rect fill="#868e96" width="100%" height="100%"/>
+                                        <text fill="#dee2e6" dy=".3em" x="40%" y="50%">Thumbnail</text>
+                                    </svg>
+                                    {#                  <img src="/media/sample.jpg" alt="sample画像">#}
+                                {% endif %}
+                                <div class="card-body">
+                                    <a class="card-text" href="{% url 'synqapp:image_detail' img.pk %}">
+                                        <p class="card-text">{{ img.name }}</p>
+                                        {# pkはprimary keyの略 #}
+                                        {{ img.created_at|date:"Y年n月j日 H:i:s" }}
+                                    </a>
+                                    <p>
+                                        <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#example-{{ forloop.counter }}" aria-expand="false" aria-controls="example-{{ forloop.counter }}">
+                                            Open
+                                        </button>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col collapse" id="example-{{ forloop.counter }}">
+                        <div class="card-group h-100">
                             <div class="card shadow-sm">
                                 {% if img.image %}
                                     <img src="{{ img.image.url }}" alt="{{ img.name }}の写真">
@@ -30,6 +62,11 @@
                                         {# pkはprimary keyの略 #}
                                         {{ img.created_at|date:"Y年n月j日 H:i:s" }}
                                     </a>
+                                    <p>
+                                        <button class="btn btn-warning" type="button" data-bs-toggle="collapse" data-bs-target="#example-{{ forloop.counter }}" aria-expand="false" aria-controls="example-{{ forloop.counter }}">
+                                            Close
+                                        </button>
+                                    </p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
- Bootstrapのcollapseを使用して、ページ遷移なしで追加の画像を表示
- [Collapse - Bootstrap](https://getbootstrap.com/docs/5.1/components/collapse/)