### PR TITLE
[update] アップロードされた画像のファイル名をハッシュ化

### DIFF
--- a/synqapp/models.py
+++ b/synqapp/models.py
@@ -2,8 +2,18 @@ from django.db import models
 from django.utils import timezone
 from django.core.validators import FileExtensionValidator
 
+from datetime import datetime
+import hashlib
 
-# Create your models here.
+
+def hash_filename(instance, filename):
+    current_time = datetime.now()
+    pre_hash_name = '%s%s%s' % (instance.name, filename, current_time)
+    extension = str(filename).split('.')[-1]
+    hs_filename = '%s.%s' % (hashlib.md5(pre_hash_name.encode()).hexdigest(), extension)
+    return hs_filename
+
+
 class Image(models.Model):
     """
     画像データ
@@ -11,8 +21,8 @@ class Image(models.Model):
     created_at = models.DateTimeField(default=timezone.now, verbose_name='作成日')
     name = models.CharField(max_length=100, verbose_name="名前")
     image = models.ImageField(null=True, blank=True,
-                              # upload_to="media",
-                              # upload_to="uploads/%Y/%m/%d/",
+                              upload_to=hash_filename,
+                              default="media/default_image.png",
                               verbose_name="添付ファイル",
                               validators=[FileExtensionValidator(["jpg", "png"])],
                               )

--- a/test/hash.py
+++ b/test/hash.py
@@ -1,0 +1,23 @@
+# ファイル名をハッシュ化するコード
+# https://freeheroblog.com/filename-hash/
+
+import os
+import hashlib
+from datetime import datetime
+
+
+def _user_profile_avator_upload_to(filename):
+    current_time = datetime.now()
+    pre_hash_name = '%s%s' % (filename, current_time)
+    extension = str(filename).split('.')[-1]
+    hs_filename = '%s.%s' % (hashlib.md5(pre_hash_name.encode()).hexdigest(), extension)
+    saved_path = 'media/'
+    return '%s%s' % (saved_path, hs_filename)
+
+
+filename = "エンジニアカタパルト.png"
+# extension = str(filename).split('.')[-1]
+# hs_filename = '%s.%s' % (hashlib.md5(file_name.encode()).hexdigest(), extension)
+# print(hs_filename) #364be8860e8d72b4358b5e88099a935a.png
+
+print(_user_profile_avator_upload_to(filename))


### PR DESCRIPTION
Closes #49 #75 

- ファイル名をハッシュ化
- [【django】画像アップロード時のファイル名のハッシュ化](https://freeheroblog.com/filename-hash/)
- ファイル名が日本語のときに生じるエラー #75 もこれにより解決