### PR TITLE
Feature/delete csrf exempt #56

### DIFF
--- a/synqapp/views.py
+++ b/synqapp/views.py
@@ -1,10 +1,6 @@
 from django.shortcuts import render
 from django.views import View
-from django.http import HttpResponse
-
 from django.views import generic
-from django.views.decorators.csrf import csrf_exempt
-from django.utils.decorators import method_decorator
 
 from .models import Image
 from .forms import ImageForm
@@ -19,17 +15,7 @@ class WelcomeView(View):
 welcome_page = WelcomeView.as_view()
 
 
-class CSRFExemptMixin(object):
-    """
-    クラス汎用ビューでも@csrf_exempt使用できるようにこのクラスを追加
-    """
-
-    @method_decorator(csrf_exempt)
-    def dispatch(self, *args, **kwargs):
-        return super(CSRFExemptMixin, self).dispatch(*args, **kwargs)
-
-
-class ImagePost(CSRFExemptMixin, generic.CreateView):
+class ImagePost(generic.CreateView):
     model = Image
     form_class = ImageForm
     template_name = "synqapp/image_form.html"


### PR DESCRIPTION
Close #56 
- csrf exemptを削除
- [【Django】 csrf_tokenの仕組みとCSRF無効化・画面カスタマイズする方法](https://djangobrothers.com/blogs/django_csrf/)