### PR TITLE
[update] サムネイル画像のサイズ変更

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -15,7 +15,9 @@
 /*写真のカード表示で，写真のサムネイルのサイズを揃える*/
 .card-customize{
     object-fit: contain;
-    aspect-ratio: 3/2;
+    aspect-ratio: 1/1;
+    width: 100%;
+    height: auto;
 }
 /*グルーピングされた画像の開閉ボタン*/
 .card-button{

--- a/synqapp/models.py
+++ b/synqapp/models.py
@@ -30,7 +30,7 @@ class Image(models.Model):
                               validators=[FileExtensionValidator(["jpg", "png"])],
                               )
     thumbnail = ImageSpecField(source='image',
-                               processors=[ResizeToFill(300, 200)],
+                               processors=[ResizeToFill(200, 200)],
                                format="JPEG",
                                options={'quality': 85}
                                # qualityはGoogleの方針に従った


### PR DESCRIPTION
Close #102 

[update] サムネイル画像をレスポンシブ表示

- style.cssのwidht and heightを指定
- [How to make Bootstrap "Cards" Responsive](https://stackoverflow.com/questions/32516886/how-to-make-bootstrap-cards-responsive)
```
.card-customize{
  width:100%;
  height:auto;
}
```